### PR TITLE
Implemented most of the topNews use case.

### DIFF
--- a/src/main/java/DataAccess/NewsAPICountry.java
+++ b/src/main/java/DataAccess/NewsAPICountry.java
@@ -29,9 +29,9 @@ public class NewsAPICountry implements ArticleFactory {
     }
 
     /**
-     * Creates n articles that are about the given country. If the number of requested
+     * Creates n articles that mention the given country. If the number of requested
      * articles exceeds the limit provided by NewsApi, the maximum number of articles is
-     * provided instead
+     * provided instead.
      *
      * @param country the country to have articles sourced from
      * @param number  the number of articles to create; negative one if it should be all of them

--- a/src/main/java/DataAccess/NewsAPITop.java
+++ b/src/main/java/DataAccess/NewsAPITop.java
@@ -1,0 +1,110 @@
+package DataAccess;
+
+import com.kwabenaberko.newsapilib.NewsApiClient;
+import com.kwabenaberko.newsapilib.models.request.TopHeadlinesRequest;
+import com.kwabenaberko.newsapilib.models.response.ArticleResponse;
+
+import entity.Article;
+import entity.ArticleFactory;
+import entity.CommonArticle;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import static java.util.Map.entry;
+
+public class NewsAPITop implements ArticleFactory {
+    private final NewsApiClient newsApiClient;
+    private final Map<String, String> supportedCountries = Map.ofEntries(
+        entry("Canada", "ca"),
+        entry("United States", "us"),
+        entry("Russia", "ru"),
+        entry("Australia", "au"),
+        entry("Brazil", "br"),
+        entry("India", "in"),
+        entry("China", "cn")
+    );
+    private List<Article> articleList;
+    private int totalResults;
+    public NewsAPITop () {
+        String API_KEY = System.getenv("API_KEY");
+        newsApiClient = new NewsApiClient(API_KEY);
+        articleList = new ArrayList<>();
+    }
+
+    /**
+     * Creates n "top headlines" from the given country. If the number of requested
+     * articles exceeds the limit provided by NewsApi, the maximum number of articles is
+     * provided instead. If the country is not in the list of supported countries
+     * for the map, null is returned.
+     * @param country the country to have articles sourced from
+     * @param number  the number of articles to create; negative one if it should be all of them
+     */
+    @Override
+    public List<Article> createArticles(String country, int number) throws InterruptedException {
+
+        // check if country is supported
+        boolean supported = false;
+        for(String s : supportedCountries.keySet()) {
+            if(s.equals(country)) {
+                supported = true;
+                break;
+            }
+        }
+
+        // if supported, continue with the API call
+        if (supported) {
+            newsApiClient.getTopHeadlines(
+                    new TopHeadlinesRequest.Builder()
+                            .country(supportedCountries.get(country))
+                            .pageSize(100)
+                            .build(),
+                    new NewsApiClient.ArticlesResponseCallback() {
+                        @Override
+                        public void onSuccess(ArticleResponse response) {
+                            totalResults = response.getTotalResults();
+                            List<Article> tempArticles = new ArrayList<>();
+                            List<com.kwabenaberko.newsapilib.models.Article> retrieved = response.getArticles();
+                            int limit;
+                            if (number == -1) limit = retrieved.size();
+                            else limit = Math.min(number, retrieved.size());
+                            for(int i = 0; i < limit; i++) {
+                                Article toAdd = new CommonArticle(
+                                        retrieved.get(i).getTitle(),
+                                        retrieved.get(i).getUrl(),
+                                        retrieved.get(i).getUrlToImage(),
+                                        retrieved.get(i).getSource().getLanguage(),
+                                        retrieved.get(i).getSource().getCountry(),
+                                        retrieved.get(i).getDescription(),
+                                        retrieved.get(i).getAuthor(),
+                                        retrieved.get(i).getSource().getId(),
+                                        retrieved.get(i).getPublishedAt(),
+                                        new Date()
+                                );
+
+                                tempArticles.add(toAdd);
+                            }
+
+                            articleList = tempArticles;
+                        }
+
+                        @Override
+                        public void onFailure(Throwable throwable) {
+                            System.out.println(throwable.getMessage());
+                        }
+                    }
+            );
+            Thread.sleep(2000);
+            return articleList;
+        }
+        else {
+            System.out.println("not supported");
+            return null;
+        }
+    }
+
+    public int getTotalResults() {
+        return totalResults;
+    }
+}

--- a/src/main/java/DataAccess/NewsAPITop.java
+++ b/src/main/java/DataAccess/NewsAPITop.java
@@ -12,19 +12,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import static java.util.Map.entry;
+import use_case.TopNews.SUPPORTED_COUNTRIES;
 
 public class NewsAPITop implements ArticleFactory {
     private final NewsApiClient newsApiClient;
-    private final Map<String, String> supportedCountries = Map.ofEntries(
-        entry("Canada", "ca"),
-        entry("United States", "us"),
-        entry("Russia", "ru"),
-        entry("Australia", "au"),
-        entry("Brazil", "br"),
-        entry("India", "in"),
-        entry("China", "cn")
-    );
+    private final Map<String, String> supportedCountries = SUPPORTED_COUNTRIES.getSupportedCountries();
     private List<Article> articleList;
     private int totalResults;
     public NewsAPITop () {

--- a/src/main/java/interface_adapters/TopNews/TopNewsController.java
+++ b/src/main/java/interface_adapters/TopNews/TopNewsController.java
@@ -1,0 +1,15 @@
+package interface_adapters.TopNews;
+
+import use_case.TopNews.TopNewsInputBoundary;
+import use_case.TopNews.TopNewsInputData;
+
+public class TopNewsController {
+    final TopNewsInputBoundary topNewsInteractor;
+    public TopNewsController(TopNewsInputBoundary topNewsInputBoundary) {
+        this.topNewsInteractor = topNewsInputBoundary;
+    }
+    public void execute() throws InterruptedException {
+        TopNewsInputData topNewsInputData = new TopNewsInputData();
+        topNewsInteractor.execute(topNewsInputData);
+    }
+}

--- a/src/main/java/interface_adapters/TopNews/TopNewsPresenter.java
+++ b/src/main/java/interface_adapters/TopNews/TopNewsPresenter.java
@@ -1,0 +1,43 @@
+package interface_adapters.TopNews;
+
+import interface_adapters.Map.MapState;
+import interface_adapters.ViewManagerModel;
+import use_case.TopNews.TopNewsOutputBoundary;
+import use_case.TopNews.TopNewsOutputData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TopNewsPresenter implements TopNewsOutputBoundary {
+    private final TopNewsViewModel topNewsViewModel;
+    private final ViewManagerModel viewManagerModel;
+
+    public TopNewsPresenter(TopNewsViewModel topNewsViewModel, ViewManagerModel viewManagerModel) {
+        this.topNewsViewModel = topNewsViewModel;
+        this.viewManagerModel = viewManagerModel;
+    }
+
+    @Override
+    public void prepareSuccessView(TopNewsOutputData topNewsOutputData) {
+
+        // Title, ImageURL, Description, URL, PublishedAt, Author
+        // Gets the current viewModel state, updates it, and sets it again, then fires a property change
+        List<List<List<String>>> articleInfo = topNewsOutputData.getArticleInfo();
+
+        TopNewsState topNewsState = topNewsViewModel.getState();
+        topNewsState.setArticleInfo(articleInfo);
+
+        List<Integer> totalResults = topNewsOutputData.getTotalResults();
+        List<Integer> sizes = new ArrayList<>();
+        // TODO: Calculate sizes of circles for each country; should be proportional to totalResults (more = bigger)
+
+        topNewsState.setSizes(sizes);
+
+        this.topNewsViewModel.setState(topNewsState);
+        topNewsViewModel.firePropertyChanged();
+
+        // Fires a property change for the viewManagerModel
+        viewManagerModel.setActiveViewName(topNewsViewModel.getViewName());
+        viewManagerModel.firePropertyChanged();
+    }
+}

--- a/src/main/java/interface_adapters/TopNews/TopNewsState.java
+++ b/src/main/java/interface_adapters/TopNews/TopNewsState.java
@@ -1,0 +1,39 @@
+package interface_adapters.TopNews;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TopNewsState {
+    // Title, ImageURL, Description, URL, PublishedAt, Author
+    List<List<List<String>>> articleInfo;
+    List<Integer> totalResults;
+    List<Integer> sizes;
+
+    public TopNewsState(){
+        sizes = new ArrayList<>();
+    }
+
+    public List<List<List<String>>> getArticleInfo() {
+        return articleInfo;
+    }
+
+    public void setArticleInfo(List<List<List<String>>> articleInfo) {
+        this.articleInfo = articleInfo;
+    }
+
+    public List<Integer> getTotalResults() {
+        return totalResults;
+    }
+
+    public void setTotalResults(List<Integer> totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    public List<Integer> getSizes() {
+        return sizes;
+    }
+
+    public void setSizes(List<Integer> sizes) {
+        this.sizes = sizes;
+    }
+}

--- a/src/main/java/interface_adapters/TopNews/TopNewsViewModel.java
+++ b/src/main/java/interface_adapters/TopNews/TopNewsViewModel.java
@@ -1,0 +1,34 @@
+package interface_adapters.TopNews;
+
+import interface_adapters.ViewModel;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+public class TopNewsViewModel extends ViewModel {
+    private TopNewsState state;
+    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
+
+    public TopNewsViewModel() {
+        super("TopNews");
+    }
+
+
+    @Override
+    public void firePropertyChanged() {
+        support.firePropertyChange("topNewsState", null, this.state);
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        support.addPropertyChangeListener(listener);
+    }
+
+    public TopNewsState getState() {
+        return state;
+    }
+
+    public void setState(TopNewsState state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/sample_api_call.java
+++ b/src/main/java/sample_api_call.java
@@ -1,3 +1,4 @@
+import DataAccess.NewsAPITop;
 import com.kwabenaberko.newsapilib.*;
 import com.kwabenaberko.newsapilib.models.request.EverythingRequest;
 import com.kwabenaberko.newsapilib.models.request.TopHeadlinesRequest;
@@ -27,6 +28,16 @@ public class sample_api_call {
         System.out.print(articles);
         System.out.println(articles.size());
         System.out.println(articles.get(0).getUrl());
+
+        System.out.println("newsapitop");
+        NewsAPITop d = new NewsAPITop();
+        List<Article> top = d.createArticles("Canada", 2);
+        System.out.println(top.get(0).getTitle());
+        System.out.println(d.getTotalResults());
+
+        top = d.createArticles("China", 3);
+        System.out.println(top.get(0).getTitle());
+        System.out.println(d.getTotalResults());
 
         // example API calls with the NewsApiClient directly
         // IMPORTANT: set environment variable with API_KEY=YOUR_API_KEY_HERE in run configurations
@@ -77,14 +88,13 @@ public class sample_api_call {
         System.out.println("top headlines");
         newsApiClient.getTopHeadlines(
                 new TopHeadlinesRequest.Builder()
-//                        .q("Japan")
-                        .country("cn")
+                        .country("us")
                         .pageSize(20)
                         .build(),
                 new NewsApiClient.ArticlesResponseCallback() {
                     @Override
                     public void onSuccess(ArticleResponse response) {
-                        for(int i = 0; i < Math.min(20, response.getTotalResults()); i++) {
+                        for(int i = 0; i < Math.min(5, response.getTotalResults()); i++) {
                             System.out.println(response.getArticles().get(i).getUrl());
                         }
 

--- a/src/main/java/use_case/TopNews/SUPPORTED_COUNTRIES.java
+++ b/src/main/java/use_case/TopNews/SUPPORTED_COUNTRIES.java
@@ -1,0 +1,38 @@
+package use_case.TopNews;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class SUPPORTED_COUNTRIES {
+
+    // remember to update both variables when adding new countries
+    private static final Map<String, String> supportedCountries = Map.ofEntries(
+            entry("Canada", "ca"),
+            entry("United States", "us"),
+            entry("Russia", "ru"),
+            entry("Australia", "au"),
+            entry("Brazil", "br"),
+            entry("India", "in"),
+            entry("China", "cn")
+    );
+    private static final List<String> supportedCountriesList = new ArrayList<>(
+            Arrays.asList(
+                    "Canada",
+                    "United States",
+                    "Russia",
+                    "Australia",
+                    "Brazil",
+                    "India",
+                    "China")
+    );
+    public static Map<String, String> getSupportedCountries() {
+        return supportedCountries;
+    }
+    public static List<String> getSupportedCountriesList() {
+        return supportedCountriesList;
+    }
+}

--- a/src/main/java/use_case/TopNews/TopNewsInputBoundary.java
+++ b/src/main/java/use_case/TopNews/TopNewsInputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.TopNews;
+
+public interface TopNewsInputBoundary {
+    void execute(TopNewsInputData topNewsInputData) throws InterruptedException;
+}

--- a/src/main/java/use_case/TopNews/TopNewsInputData.java
+++ b/src/main/java/use_case/TopNews/TopNewsInputData.java
@@ -1,0 +1,12 @@
+package use_case.TopNews;
+
+public class TopNewsInputData {
+//    final private String countryName;
+
+    public TopNewsInputData() {
+    }
+
+//    public String getCountryName() {
+//        return countryName;
+//    }
+}

--- a/src/main/java/use_case/TopNews/TopNewsInteractor.java
+++ b/src/main/java/use_case/TopNews/TopNewsInteractor.java
@@ -1,0 +1,45 @@
+package use_case.TopNews;
+
+import DataAccess.NewsAPITop;
+import entity.Article;
+import entity.ArticleFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TopNewsInteractor implements TopNewsInputBoundary {
+    final TopNewsOutputBoundary topNewsOutputPresenter;
+    public TopNewsInteractor(TopNewsOutputBoundary topNewsOutputBoundary) {
+        this.topNewsOutputPresenter = topNewsOutputBoundary;
+    }
+    @Override
+    public void execute(TopNewsInputData topNewsInputData) throws InterruptedException {
+        NewsAPITop articleFactory = new NewsAPITop();
+        List<List<List<String>>> countriesArticles = new ArrayList<>();
+        List<Integer> totalResults = new ArrayList<>();
+
+        for(String country:SUPPORTED_COUNTRIES.getSupportedCountriesList()) {
+            // n = -1 indicates "get all articles"
+            List<Article> articles = articleFactory.createArticles(country, -1);
+            List<List<String>> countryArticles = new ArrayList<>();
+            // convert to string and extract select fields
+            for (Article a: articles) {
+                List<String> x = new ArrayList<>();
+                x.add(a.getTitle());
+                x.add(a.getImageUrl());
+                x.add(a.getDescription());
+                x.add(a.getUrl());
+                x.add(a.getPublishedAt());
+                x.add(a.getAuthor());
+                countryArticles.add(x);
+            }
+            // articleInfo
+            countriesArticles.add(countryArticles);
+            // totalResults
+            totalResults.add(articleFactory.getTotalResults());
+        }
+
+        TopNewsOutputData topNewsOutputData = new TopNewsOutputData(countriesArticles, totalResults);
+        topNewsOutputPresenter.prepareSuccessView(topNewsOutputData);
+    }
+}

--- a/src/main/java/use_case/TopNews/TopNewsOutputBoundary.java
+++ b/src/main/java/use_case/TopNews/TopNewsOutputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.TopNews;
+
+public interface TopNewsOutputBoundary {
+    void prepareSuccessView(TopNewsOutputData topNewsOutputData);
+}

--- a/src/main/java/use_case/TopNews/TopNewsOutputData.java
+++ b/src/main/java/use_case/TopNews/TopNewsOutputData.java
@@ -1,0 +1,31 @@
+package use_case.TopNews;
+
+import entity.Article;
+
+import java.util.List;
+
+public class TopNewsOutputData {
+
+    // Our program's supported countries
+    private final List<String> supportedCountries = SUPPORTED_COUNTRIES.getSupportedCountriesList();
+    // A list of lists of strings where each list of strings corresponds to an article,
+    // the list of lists of strings represents a list of articles, and the list of lists of articles has
+    // one list of articles for a country in supportedCountries in the same order they appear
+    private List<List<List<String>>> articleInfo;
+
+    // A list of integers representing the number of articles published in the last month.
+    // The integers are in the same order as supportedCountries.
+    private List<Integer> totalResults;
+    TopNewsOutputData(List<List<List<String>>> articleInfo, List<Integer> totalResults) {
+        this.articleInfo = articleInfo;
+        this.totalResults = totalResults;
+    }
+
+    public List<List<List<String>>> getArticleInfo() {
+        return articleInfo;
+    }
+
+    public List<Integer> getTotalResults() {
+        return totalResults;
+    }
+}


### PR DESCRIPTION
This use case will be run on the app's start up. It fetches information about "top news" using the Top Headlines endpoint of NewsAPi from each of the app's supported countries and stores/prepares them to be viewed. It will also keep track of the number of articles published about the given countries in the last month. Using that data, it will draw circles on the map in each of the supported countries, where the size of the circle is relative to the number of articles published. Thus, it will be visibly apparent which countries are currently news hotspots.

Related todos:
- Determine precise formula/calculations that will map the number of articles to the size of circle that should be drawn.
- Implement the view.
- Connect this use case with the map use case: after displaying the circles on the countries, the user should be able to click on them and have the stored articles appear in a side banner.